### PR TITLE
Only allow the setup to run once

### DIFF
--- a/lua/commentary/init.lua
+++ b/lua/commentary/init.lua
@@ -84,6 +84,9 @@ M.setup = function(opts)
 		vim.api.nvim_set_keymap("n", "gcc", "<Plug>commentary", { silent = true })
 		vim.api.nvim_set_keymap("n", "gc", "<Plug>commentary_motion", { silent = true })
 	end
+
+  -- only run the setup once
+  vim.g.loaded_commentary = true
 end
 
 M.use_default_mappings = function()


### PR DESCRIPTION
Only allowing the setup function to run once, this will stop it from overriding the custom languages.

This issue should fix this https://github.com/shoukoo/commentary.nvim/issues/1